### PR TITLE
Add a reusable workflow that fixes PR code style

### DIFF
--- a/.github/workflows/fix-code-style.yml
+++ b/.github/workflows/fix-code-style.yml
@@ -1,0 +1,97 @@
+name: Fix code style
+
+# Reusable workflow: fixes the code style of the PHP files a pull request touches and
+# commits the result back to the PR branch. Call it from a consuming repository —
+# see the "GitHub Actions" section of the README.
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: PHP version used to run the fixer.
+        type: string
+        required: false
+        default: '8.3'
+      runs-on:
+        description: Runner label for the job.
+        type: string
+        required: false
+        default: ubuntu-latest
+    secrets:
+      app-client-id:
+        description: Client ID of a GitHub App installed on the calling repository with contents:write.
+        required: true
+      app-private-key:
+        description: Private key of that GitHub App.
+        required: true
+
+jobs:
+  fix-code-style:
+    runs-on: ${{ inputs.runs-on }}
+
+    # Fork PRs receive no secrets, so the app token cannot be minted — skip instead of failing.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    permissions:
+      # The style commit is made with the app token below, not with GITHUB_TOKEN.
+      contents: read
+
+    steps:
+      # Commits made with GITHUB_TOKEN never trigger further workflow runs, which would leave
+      # the PR's required checks unreported against the style commit. An app installation token
+      # is a separate identity, so the resulting `synchronize` event re-runs them.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.app-client-id }}
+          private-key: ${{ secrets.app-private-key }}
+          permission-contents: write
+
+      - uses: actions/checkout@v7
+        with:
+          # Check out the PR branch itself — the detached merge commit that pull_request events
+          # check out by default is not a branch we can commit to.
+          ref: ${{ github.head_ref }}
+          # Full history so changed files can be diffed against the base branch.
+          fetch-depth: 0
+          # Nothing pushes from the runner; the commit is made over the API.
+          persist-credentials: false
+
+      - name: Get changed php files
+        id: changed-files
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- '*.php' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Setup PHP
+        if: steps.changed-files.outputs.files != ''
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          tools: composer:v2
+
+      - name: Install ringier-code-style
+        if: steps.changed-files.outputs.files != ''
+        run: composer global require ringierimu/ringier-code-style
+
+      - name: Fix code style
+        if: steps.changed-files.outputs.files != ''
+        run: |
+          ringier-code-style config:dump --all --quiet
+          ringier-code-style fix ${{ steps.changed-files.outputs.files }}
+
+      # Commits created through GitHub's GraphQL API are signed with GitHub's own key, so they
+      # land Verified on a branch that requires signed commits — no signing key to manage here.
+      - name: Commit fixes
+        if: steps.changed-files.outputs.files != ''
+        uses: planetscale/ghcommit-action@v0.2.22
+        with:
+          commit_message: Apply ringier-code-style changes
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref }}
+          # Stage only the files handed to the fixer: `config:dump` writes config files into the
+          # working tree, and those must not ride along in the commit.
+          file_pattern: ${{ steps.changed-files.outputs.files }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,41 @@ vendor/bin/ringier-code-style fix ...files...
 vendor/bin/ringier-code-style config:dump --all
 ```
 
+### Fix code style automatically on every pull request
+
+`fix-code-style.yml` is a reusable workflow. It fixes the PHP files a pull request touches and
+commits the result straight back to the PR branch:
+
+```yaml
+# .github/workflows/ringier-code-style.yml
+name: ringier-code-style
+
+on:
+  pull_request:
+
+jobs:
+  fix-code-style:
+    # Pin to a release tag: https://github.com/RingierIMU/ringier-code-style/releases
+    uses: RingierIMU/ringier-code-style/.github/workflows/fix-code-style.yml@<tag>
+    with:
+      php-version: '8.3'      # optional, defaults to 8.3
+      runs-on: ubuntu-latest  # optional, defaults to ubuntu-latest
+    secrets:
+      app-client-id: ${{ secrets.STYLE_BOT_CLIENT_ID }}
+      app-private-key: ${{ secrets.STYLE_BOT_PRIVATE_KEY }}
+```
+
+The two secrets are the Client ID and private key of a GitHub App installed on your repository
+with the **Contents: read and write** permission. A GitHub App is used rather than the default
+`GITHUB_TOKEN` for two reasons:
+
+- Commits made with `GITHUB_TOKEN` do not trigger further workflow runs, so the pull request's
+  required checks would never report against the style commit and the PR would stay blocked.
+- The commit is created through GitHub's GraphQL API, which signs it with GitHub's own key. It
+  therefore shows as **Verified** and is accepted on branches that require signed commits.
+
+Pull requests opened from forks are skipped, because forks receive no secrets.
+
 ## Contriubutions
 
 ### Update dependencies

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ vendor/bin/ringier-code-style config:dump --all
 ### Fix code style automatically on every pull request
 
 `fix-code-style.yml` is a reusable workflow. It fixes the PHP files a pull request touches and
-commits the result straight back to the PR branch:
+commits the result straight back to the PR branch. Drop the caller into your repository with:
+
+```bash
+vendor/bin/ringier-code-style config:dump --workflow
+```
+
+which writes:
 
 ```yaml
 # .github/workflows/ringier-code-style.yml
@@ -34,21 +40,34 @@ name: ringier-code-style
 on:
   pull_request:
 
+concurrency:
+  # Cancel superseded runs on rapid pushes so two runs never race to commit fixes.
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
-  fix-code-style:
+  ringier-code-style:
+    # The job lives in the fixer's own repo, so a fix to it reaches every consuming repo.
     # Pin to a release tag: https://github.com/RingierIMU/ringier-code-style/releases
-    uses: RingierIMU/ringier-code-style/.github/workflows/fix-code-style.yml@<tag>
+    uses: RingierIMU/ringier-code-style/.github/workflows/fix-code-style.yml@main
     with:
-      php-version: '8.3'      # optional, defaults to 8.3
-      runs-on: ubuntu-latest  # optional, defaults to ubuntu-latest
+      runs-on: ubicloud-standard-2-arm
     secrets:
-      app-client-id: ${{ secrets.STYLE_BOT_CLIENT_ID }}
-      app-private-key: ${{ secrets.STYLE_BOT_PRIVATE_KEY }}
+      # Organisation secrets: the Client ID and private key of a GitHub App installed on
+      # this repository with the Contents: read and write permission.
+      app-client-id: ${{ secrets.PR_SIGNING_BOT_CLIENT_ID }}
+      app-private-key: ${{ secrets.PR_SIGNING_BOT_PRIVATE_KEY }}
 ```
 
+Both `with:` inputs are optional: `php-version` defaults to `8.3` and `runs-on` to
+`ubuntu-latest`.
+
 The two secrets are the Client ID and private key of a GitHub App installed on your repository
-with the **Contents: read and write** permission. A GitHub App is used rather than the default
-`GITHUB_TOKEN` for two reasons:
+with the **Contents: read and write** permission. In the RingierIMU organisation they already exist
+as the organisation secrets `PR_SIGNING_BOT_CLIENT_ID` and `PR_SIGNING_BOT_PRIVATE_KEY`; grant your
+repository access to them rather than creating a second app.
+
+A GitHub App is used rather than the default `GITHUB_TOKEN` for two reasons:
 
 - Commits made with `GITHUB_TOKEN` do not trigger further workflow runs, so the pull request's
   required checks would never report against the style commit and the PR would stay blocked.

--- a/stubs/.github/workflows/ringier-code-style.yml
+++ b/stubs/.github/workflows/ringier-code-style.yml
@@ -4,56 +4,19 @@ on:
   pull_request:
 
 concurrency:
-  # Cancel superseded runs on rapid pushes so two runs never race to push fixes.
+  # Cancel superseded runs on rapid pushes so two runs never race to commit fixes.
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
   ringier-code-style:
-    runs-on: ubicloud-standard-2-arm
-
-    # GITHUB_TOKEN cannot push to a fork's branch — skip PRs from forks instead of failing.
-    if: github.event.pull_request.head.repo.full_name == github.repository
-
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # Check out the PR branch itself — git-auto-commit-action errors on the
-          # detached merge commit that pull_request events check out by default.
-          ref: ${{ github.head_ref }}
-          # Required to push commits back to the repository.
-          persist-credentials: true
-          # Full history so changed files can be diffed against the base branch.
-          fetch-depth: 0
-
-      - name: Get changed php files
-        id: changed-files
-        run: |
-          files=$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- '*.php' | tr '\n' ' ')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
-
-      - name: Setup PHP
-        if: steps.changed-files.outputs.files != ''
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          tools: composer:v2
-
-      - name: Install ringier-code-style
-        if: steps.changed-files.outputs.files != ''
-        run: composer global require ringierimu/ringier-code-style
-
-      - name: Fix code style
-        if: steps.changed-files.outputs.files != ''
-        run: |
-          ringier-code-style config:dump --all --quiet
-          ringier-code-style fix ${{ steps.changed-files.outputs.files }}
-
-      - uses: stefanzweifel/git-auto-commit-action@v7
-        if: steps.changed-files.outputs.files != ''
-        with:
-          commit_message: Apply ringier-code-style changes
+    # The job lives in the fixer's own repo, so a fix to it reaches every consuming repo.
+    # Pin to a release tag: https://github.com/RingierIMU/ringier-code-style/releases
+    uses: RingierIMU/ringier-code-style/.github/workflows/fix-code-style.yml@main
+    with:
+      runs-on: ubicloud-standard-2-arm
+    secrets:
+      # Organisation secrets: the Client ID and private key of a GitHub App installed on
+      # this repository with the Contents: read and write permission.
+      app-client-id: ${{ secrets.PR_SIGNING_BOT_CLIENT_ID }}
+      app-private-key: ${{ secrets.PR_SIGNING_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Adds `.github/workflows/fix-code-style.yml` as a **reusable workflow**, plus a README section documenting it.

Consuming repos drop the copy-pasted job and call this instead:

```yaml
jobs:
  fix-code-style:
    uses: RingierIMU/ringier-code-style/.github/workflows/fix-code-style.yml@<tag>
    secrets:
      app-client-id: ${{ secrets.STYLE_BOT_CLIENT_ID }}
      app-private-key: ${{ secrets.STYLE_BOT_PRIVATE_KEY }}
```

## Why

Every repo using the fixer maintains its own copy of the same job, so a fix to it lands in one repo and nowhere else.

Two things are fixed relative to the job that has been copied around:

1. **The commit is now signed.** It is created through GitHub's GraphQL API (`planetscale/ghcommit-action`), which GitHub signs with its own key. `git-auto-commit-action` shells out to `git commit` with no key, so its commits were `Unverified` and are rejected outright on branches with *Require signed commits* enabled.
2. **The commit now triggers the PR's other workflows.** [Events triggered by `GITHUB_TOKEN` do not create new workflow runs](https://docs.github.com/en/actions/concepts/security/github_token), so a style commit became the new head SHA with no checks reported against it and the PR sat blocked on *Expected — waiting for status*. The job now authenticates with a GitHub App installation token, which is a separate identity.

## Setup required by consumers

A GitHub App installed on the repo with **Contents: read and write**, and its Client ID + private key stored as repo secrets. Documented in the README section this PR adds.

## Notes

- Inputs `php-version` (default `8.3`) and `runs-on` (default `ubuntu-latest`) are overridable; `ubuntu-latest` is the default so repos without ubicloud runners work out of the box.
- Fork PRs are skipped — they receive no secrets, so the app token cannot be minted.
- Only the files handed to the fixer are staged, so the config files `config:dump --all` writes into the working tree cannot ride along in the commit.
- Needs a release tag cut before consumers can pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzwkAWAvjiD63nHxvgjkru